### PR TITLE
v1.7.2: Update summit webcam to ALERTCalifornia live cam

### DIFF
--- a/diablo/lib/features/weather/weather_screen.dart
+++ b/diablo/lib/features/weather/weather_screen.dart
@@ -77,7 +77,7 @@ class WeatherScreen extends StatelessWidget {
               Icons.landscape,
               Colors.orange,
               'https://mesowest.utah.edu/cgi-bin/droman/meso_base.cgi?stn=SJS02',
-              webcamUrl,
+              'https://ops.alertcalifornia.org/cam-console/2156',
             ),
             const SizedBox(height: 12),
             _buildWeatherStationTile(
@@ -138,7 +138,7 @@ class WeatherScreen extends StatelessWidget {
               Icons.landscape,
               Colors.purple,
               'https://map.purpleair.com/?opt=1/mAQI/a10/cC0&key=WZRAE0D746KP9G67&select=91079#11/37.8817/-121.9146',
-              webcamUrl,
+              'https://ops.alertcalifornia.org/cam-console/2156',
             ),
             const SizedBox(height: 12),
             _buildAirQualityTile(

--- a/diablo/pubspec.yaml
+++ b/diablo/pubspec.yaml
@@ -2,7 +2,7 @@ name: diablo
 description: "Mount Diablo Contra Costa County - Official visitor guide and outdoor recreation app."
 publish_to: 'none' # Prevents accidental publishing to pub.dev
 
-version: 1.7.1+1
+version: 1.7.2+1
 
 environment:
   sdk: ^3.5.4


### PR DESCRIPTION
- Replace generic meteoblue webcam link with ALERTCalifornia Mt Diablo summit cam for Summit Weather and Summit AQI entries
- Version bumped to 1.7.2+1